### PR TITLE
Suggested fix for issue #10

### DIFF
--- a/src/regsem_rcpp_RAMmult.cpp
+++ b/src/regsem_rcpp_RAMmult.cpp
@@ -74,7 +74,7 @@ arma::mat S3 = Rcpp::as<arma::mat>(S2);
 
 
 
-arma::mat ImpCov = F3 * inv(I3-A3) * S3 * (inv(I3-A3)).t() * F3.t();
+arma::mat ImpCov = F3 * pinv(I3-A3) * S3 * (pinv(I3-A3)).t() * F3.t();
 
 
 return Rcpp::List::create(

--- a/src/regsem_rcpp_fit_fun.cpp
+++ b/src/regsem_rcpp_fit_fun.cpp
@@ -49,7 +49,7 @@ arma::mat SampCov2 = Rcpp::as<arma::mat>(SampCov);
 //S2 = clone(S);
 
 //if (estimator2 == 1) { // ML
-  fit_base = log(det(ImpCov2)) + trace(SampCov2 * (inv(ImpCov2))) - log(det(SampCov2))  - m;
+  fit_base = log(det(ImpCov2)) + trace(SampCov2 * (pinv(ImpCov2))) - log(det(SampCov2))  - m;
 //}
 //else if (estimator2 == 2) {
 //   fit_base = as_scalar((poly_vec - imp_vec).t() * (poly_vec - imp_vec));


### PR DESCRIPTION
On some systems, one may be told that the model-implied covariance matrix is not positive-definite when inverting it during the fit process.

The theory was that this is a numerical issue - another possibility is that this occurs when the estimation results in under-identified models for some values of lambda. 

My suggestion is to calculate pseudo-inverses instead. If the covariance matrix is positive definite, the pseudo-inverse is equivalent to the actual inverse. In the border cases where the matrix is just a bit off an invertible matrix, the difference should be negligible. In cases where it is way off, one should actually notice this as really non-identified models tend to yield unreasonable estimates.